### PR TITLE
Speed up time to ready

### DIFF
--- a/DatArchive.js
+++ b/DatArchive.js
@@ -19,8 +19,6 @@ const hyperdrive = require('hyperdrive')
 const crypto = require('hypercore/lib/crypto')
 const hexTo32 = require('hex-to-32')
 
-const REPLICATION_DELAY = 3000
-
 // Gateways are hella slow so we'll have a crazy long timeout
 const API_TIMEOUT = 15 * 1000
 
@@ -391,12 +389,6 @@ function waitOpen (stream) {
       stream.removeListener('data', onData)
       reject(e)
     }
-  })
-}
-
-function waitReplication () {
-  return new Promise((resolve) => {
-    setTimeout(resolve, REPLICATION_DELAY)
   })
 }
 

--- a/DatArchive.js
+++ b/DatArchive.js
@@ -73,8 +73,14 @@ class DatArchive {
 
       await waitOpen(stream)
 
-      if (url) {
-        await waitReplication()
+      if (!archive.writable && !archive.metadata.length) {
+        // wait to receive a first update
+        await new Promise((resolve, reject) => {
+          archive.metadata.update(err => {
+            if (err) reject(err)
+            else resolve()
+          })
+        })
       }
     })
   }


### PR DESCRIPTION
Avoid the 3s timeout when setting up replication by using the metadata status. Is how [node-dat-archive](https://github.com/beakerbrowser/node-dat-archive/blob/master/index.js#L70) is checking for data availability when a new archive is created.

Testing with my [DatArchive Test suite](https://github.com/sammacbeth/dat-archive-compat-tests), this speeds up the initialisation enough to beat the 2s timeouts that these tests have.